### PR TITLE
Fix YCB-V data annotation script

### DIFF
--- a/data_utils/data_annotation/ycbv2poet.py
+++ b/data_utils/data_annotation/ycbv2poet.py
@@ -36,7 +36,7 @@ categories = [
     {'supercategory': '036_wood_block', 'id': 16, 'name': '036_wood_block'},
     {'supercategory': '037_scissors', 'id': 17, 'name': '037_scissors'},
     {'supercategory': '040_large_marker', 'id': 18, 'name': '040_large_marker'},
-    {'supercategory': '051_large_clamp', 'id': 19, 'name': '052_large_clamp'},
+    {'supercategory': '051_large_clamp', 'id': 19, 'name': '051_large_clamp'},
     {'supercategory': '052_extra_large_clamp', 'id': 20, 'name': '052_extra_large_clamp'},
     {'supercategory': '061_foam_brick', 'id': 21, 'name': '061_foam_brick'},
 ]

--- a/data_utils/data_annotation/ycbv2poet.py
+++ b/data_utils/data_annotation/ycbv2poet.py
@@ -9,7 +9,7 @@ import os
 import cv2
 
 base_path = '/data'
-data_paths = ['train_real/', 'train_synt']
+data_paths = ['train_real/', 'train_synt/']
 img_types = ['real', 'synt']
 
 

--- a/data_utils/data_annotation/ycbv2poet.py
+++ b/data_utils/data_annotation/ycbv2poet.py
@@ -9,8 +9,8 @@ import os
 import cv2
 
 base_path = '/data'
-data_paths = ['train_real/', 'train_synt/']
-img_types = ['real', 'synt']
+data_paths = ['test/', 'train_real/', 'train_synt/']
+img_types = ['real', 'synt', 'test']
 
 
 output_base_path = '/data/ycbv/annotations/'

--- a/data_utils/data_annotation/ycbv2poet.py
+++ b/data_utils/data_annotation/ycbv2poet.py
@@ -22,7 +22,7 @@ categories = [
     {'supercategory': '003_cracker_box', 'id': 2, 'name': '003_cracker_box'},
     {'supercategory': '004_sugar_box', 'id': 3, 'name': '004_sugar_box'},
     {'supercategory': '005_tomato_soup_can', 'id': 4, 'name': '005_tomato_soup_can'},
-    {'supercategory': '006_mustard_bootle', 'id': 5, 'name': '006_mustard_bootle'},
+    {'supercategory': '006_mustard_bottle', 'id': 5, 'name': '006_mustard_bottle'},
     {'supercategory': '007_tuna_fish_can', 'id': 6, 'name': '007_tuna_fish_can'},
     {'supercategory': '008_pudding_box', 'id': 7, 'name': '008_pudding_box'},
     {'supercategory': '009_gelatin_box', 'id': 8, 'name': '009_gelatin_box'},


### PR DESCRIPTION
The `data_paths` in the annotation script for YCB-V were missing a trailing slash, causing a `FileNotFoundError`.